### PR TITLE
also handle peertube

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FreshRSS - YouTube video extension
 
-This FreshRSS extension allows you to directly watch YouTube videos from within subscribed channel feeds.
+This FreshRSS extension allows you to directly watch YouTube/PeerTube videos from within subscribed channel feeds.
 
 To use it, upload the ```xExtension-YouTube``` directory to the FreshRSS `./extensions` directory on your server and enable it on the extension panel in FreshRSS.
 
@@ -31,6 +31,9 @@ With activated Youtube extension:
 More extensions can be found at [FreshRSS/Extensions](https://github.com/FreshRSS/Extensions).
 
 ## Changelog
+
+0.7:
+* Support for PeerTube feed
 
 0.6: 
 * Support cookie-less domain www.youtube-nocookie.com for embedding 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -106,7 +106,7 @@ class YouTubeExtension extends Minz_Extension
     {
         $link = $entry->link();
 
-        if (stripos($link, 'www.youtube.com/watch?v=') === false) {
+        if (stripos($link, 'www.youtube.com/watch?v=') === false and stripos($link, 'videos/watch/') === false) {
             return $entry;
         }
 
@@ -115,9 +115,12 @@ class YouTubeExtension extends Minz_Extension
         if (stripos($entry->content(), '<iframe class="youtube-plugin-video"') !== false) {
             return $entry;
         }
-
-        $html = $this->getIFrameForLink($link);
-
+        if (stripos($link, 'www.youtube.com/watch?v=') !== false) {
+            $html = $this->getIFrameForLink($link);
+        }
+        else{ //peertube
+            $html = $this->getPeerTubeIFrameForLink($link);
+        }
         if ($this->showContent) {
             $html .= $entry->content();
         }
@@ -144,6 +147,20 @@ class YouTubeExtension extends Minz_Extension
 
         $html = $this->getIFrameHtml($url);
 
+        return $html;
+    }
+
+    /**
+    * Returns an HTML <iframe> for a given PeerTube watch URL
+    *
+    * @param string $link
+    * @return string
+    */
+    public function getPeerTubeIFrameForLink($link)
+    {
+        $url = str_replace('/watch', '/embed', $link);
+        $html = $this->getIFrameHtml($url);
+        
         return $html;
     }
 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -106,7 +106,7 @@ class YouTubeExtension extends Minz_Extension
     {
         $link = $entry->link();
 
-        if (stripos($link, 'www.youtube.com/watch?v=') === false and stripos($link, 'videos/watch/') === false) {
+        if (preg_match('#^https?://www\.youtube\.com/watch\?v=|/videos/watch/[0-9a-f-]{36}$#', $link) !== 1) {
             return $entry;
         }
 

--- a/xExtension-YouTube/metadata.json
+++ b/xExtension-YouTube/metadata.json
@@ -1,8 +1,8 @@
 {
-	"name": "YouTube Video Feed",
+	"name": "YouTube/PeerTube Video Feed",
 	"author": "Kevin Papst",
-	"description": "Embed YouTube feeds inside article content.",
-	"version": 0.6,
+	"description": "Embed YouTube/PeerTube feeds inside article content.",
+	"version": 0.7,
 	"entrypoint": "YouTube",
 	"type": "system"
 }


### PR DESCRIPTION
Hi !

PeerTube is a free alternative of youtube based on activity pub, like mastodon pleroma etc and a lot of users are using it so I've just made a little improvement to also handle peertube videos. because it is base on instances I couldn't recognize peertube urls with domain name but it should be ok