### PR TITLE
Convert URL on check_url_before_add

### DIFF
--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -36,7 +36,7 @@ class YouTubeExtension extends Minz_Extension
     public function init()
     {
         $this->registerHook('entry_before_display', array($this, 'embedYouTubeVideo'));
-        $this->registerHook('feed_before_insert', array($this, 'convertYoutubeFeedUrl'));
+        $this->registerHook('check_url_before_add', array($this, 'convertYoutubeFeedUrl'));
         $this->registerTranslates();
     }
 
@@ -44,19 +44,19 @@ class YouTubeExtension extends Minz_Extension
      * @param FreshRSS_Feed $feed
      * @return FreshRSS_Feed
      */
-    public function convertYoutubeFeedUrl($feed)
+    public function convertYoutubeFeedUrl($url)
     {
         $matches = [];
 
-        if (preg_match('#^https?://www\.youtube\.com/channel/([0-9a-zA-Z_-]{6,36})$#', $feed->url(), $matches) !== 1) {
-            if (preg_match('#^https?://www\.youtube\.com/user/([0-9a-zA-Z_-0]{6,36})$#', $feed->url(), $matches) !== 1) {
-                return $feed;
-            }
+        if (preg_match('#^https?://www\.youtube\.com/channel/([0-9a-zA-Z_-]{6,36})$#', $url, $matches) === 1) {
+            return 'https://www.youtube.com/feeds/videos.xml?channel_id=' . $matches[1];
         }
 
-        $feed->_url('https://www.youtube.com/feeds/videos.xml?channel_id=' . $matches[1]);
+        if (preg_match('#^https?://www\.youtube\.com/user/([0-9a-zA-Z_-]{6,36})$#', $url, $matches) === 1) {
+            return 'https://www.youtube.com/feeds/videos.xml?user=' . $matches[1];
+        }
 
-        return $feed;
+        return $url;
     }
 
     /**


### PR DESCRIPTION
SimplePie is redirected by Youtube on some channels, and we might end up
on a totally different page. By using the `check_url_before_add` hook,
we change the URL before the call to SimplePie.

It works with all the URLs mentioned in https://github.com/kevinpapst/freshrss-youtube/pull/11