### PR TITLE
Better rendering of the YouTube feed content.

### DIFF
--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -1,41 +1,41 @@
-<form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())) ?>" method="post">
-	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
+<form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
+	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
 	<div class="form-group">
 
-		<label class="group-name" for="yt_height"><?= _t('ext.yt_videos.height') ?></label>
+		<label class="group-name" for="yt_height"><?php echo _t('ext.yt_videos.height'); ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_height" name="yt_height" value="<?= $this->getHeight() ?>" min="50" data-leave-validation="1">
+			<input type="number" id="yt_height" name="yt_height" value="<?php echo $this->getHeight(); ?>" min="50" data-leave-validation="1">
 		</div>
 
-		<label class="group-name" for="yt_width"><?= _t('ext.yt_videos.width') ?></label>
+		<label class="group-name" for="yt_width"><?php echo _t('ext.yt_videos.width'); ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_width" name="yt_width" value="<?= $this->getWidth() ?>" min="100" data-leave-validation="1">
+			<input type="number" id="yt_width" name="yt_width" value="<?php echo $this->getWidth(); ?>" min="100" data-leave-validation="1">
 		</div>
 		
 		<div class="group-controls">
 			<label class="checkbox" for="yt_show_content">
-				<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->isShowContent() ? 'checked' : '' ?>>
-				<?= _t('ext.yt_videos.show_content') ?>
+				<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?php echo $this->isShowContent() ? 'checked' : ''; ?>>
+				<?php echo _t('ext.yt_videos.show_content'); ?>
 			</label>
 		</div>
 
 		<div class="group-controls">
 			<label class="checkbox" for="yt_nocookie">
-				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->isUseNoCookieDomain() ? 'checked' : '' ?>>
-				<?= _t('ext.yt_videos.use_nocookie') ?>
+				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?php echo $this->isUseNoCookieDomain() ? 'checked' : ''; ?>>
+				<?php echo _t('ext.yt_videos.use_nocookie'); ?>
 			</label>
 		</div>
 	</div>
 
 	<div class="form-group form-actions">
 		<div class="group-controls">
-			<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
-			<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
+			<button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
+			<button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
 		</div>
 	</div>
 </form>
 
 <p>
-	<?= _t('ext.yt_videos.updates') ?>
+	<?php echo _t('ext.yt_videos.updates'); ?>
 	<a href="https://github.com/kevinpapst/freshrss-youtube" target="_blank">GitHub</a>.
 </p>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -14,7 +14,7 @@
 		
 		<label class="group-name" for="yt_show_content"><?= _t('ext.yt_videos.show_content') ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->getShowContent() ? 'checked' : '' ?>>
+			<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->isShowContent() ? 'checked' : '' ?>>
 		</div>
 
 		<label class="group-name" for="yt_nocookie"><?= _t('ext.yt_videos.use_nocookie') ?></label>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -12,14 +12,18 @@
 			<input type="number" id="yt_width" name="yt_width" value="<?= $this->getWidth() ?>" min="100" data-leave-validation="1">
 		</div>
 		
-		<label class="group-name" for="yt_show_content"><?= _t('ext.yt_videos.show_content') ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->isShowContent() ? 'checked' : '' ?>>
+			<label class="checkbox" for="yt_show_content">
+				<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->isShowContent() ? 'checked' : '' ?>>
+				<?= _t('ext.yt_videos.show_content') ?>
+			</label>
 		</div>
 
-		<label class="group-name" for="yt_nocookie"><?= _t('ext.yt_videos.use_nocookie') ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->getUseNoCookie() ? 'checked' : '' ?>>
+			<label class="checkbox" for="yt_nocookie">
+				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->getUseNoCookie() ? 'checked' : '' ?>>
+				<?= _t('ext.yt_videos.use_nocookie') ?>
+			</label>
 		</div>
 	</div>
 

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -14,11 +14,20 @@
 			<input type="number" id="yt_width" name="yt_width" value="<?php echo $this->getWidth(); ?>" min="100" data-leave-validation="1">
 		</div>
 		
-		<label class="group-name" for="yt_content"><?php echo _t('ext.yt_videos.content.title'); ?></label>
+		<label class="group-name" for="yt_content_none"><?php echo _t('ext.yt_videos.content.title'); ?></label>
 		<div class="group-controls">
-			<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?php if ($this->getContentHandling() === 'none') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.none'); ?><br />
-			<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?php if ($this->getContentHandling() === 'append') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.append'); ?><br />
-			<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?php if ($this->getContentHandling() === 'format') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.format'); ?><br />
+			<label for="yt_content_none">
+				<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?= $this->getContentHandling() === 'none' ? 'checked' : '' ?>>
+				<?php echo _t('ext.yt_videos.content.none'); ?>
+			</label>
+			<label for="yt_content_append">
+				<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?= $this->getContentHandling() === 'append' ? 'checked' : '' ?>>
+				<?php echo _t('ext.yt_videos.content.append'); ?>
+			</label>
+			<label for="yt_content_format">
+				<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?= $this->getContentHandling() === 'format' ? 'checked' : '' ?>>
+				<?php echo _t('ext.yt_videos.content.format'); ?>
+			</label>
 		</div>
 
 		<label class="group-name" for="yt_nocookie"><?php echo _t('ext.yt_videos.use_nocookie'); ?></label>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -1,48 +1,37 @@
-<form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
-	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
+<form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())) ?>" method="post">
+	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 	<div class="form-group">
 
-		<label class="group-name" for="yt_height"><?php echo _t('ext.yt_videos.height'); ?></label>
+		<label class="group-name" for="yt_height"><?= _t('ext.yt_videos.height') ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_height" name="yt_height" value="<?php echo $this->getHeight(); ?>" min="50" data-leave-validation="1">
+			<input type="number" id="yt_height" name="yt_height" value="<?= $this->getHeight() ?>" min="50" data-leave-validation="1">
 		</div>
 
-		<label class="group-name" for="yt_width"><?php echo _t('ext.yt_videos.width'); ?></label>
+		<label class="group-name" for="yt_width"><?= _t('ext.yt_videos.width') ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_width" name="yt_width" value="<?php echo $this->getWidth(); ?>" min="100" data-leave-validation="1">
+			<input type="number" id="yt_width" name="yt_width" value="<?= $this->getWidth() ?>" min="100" data-leave-validation="1">
 		</div>
 		
-		<label class="group-name" for="yt_content_none"><?php echo _t('ext.yt_videos.content.title'); ?></label>
+		<label class="group-name" for="yt_show_content"><?= _t('ext.yt_videos.show_content') ?></label>
 		<div class="group-controls">
-			<label for="yt_content_none">
-				<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?= $this->getContentHandling() === 'none' ? 'checked' : '' ?>>
-				<?php echo _t('ext.yt_videos.content.none'); ?>
-			</label>
-			<label for="yt_content_append">
-				<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?= $this->getContentHandling() === 'append' ? 'checked' : '' ?>>
-				<?php echo _t('ext.yt_videos.content.append'); ?>
-			</label>
-			<label for="yt_content_format">
-				<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?= $this->getContentHandling() === 'format' ? 'checked' : '' ?>>
-				<?php echo _t('ext.yt_videos.content.format'); ?>
-			</label>
+			<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?= $this->getShowContent() ? 'checked' : '' ?>>
 		</div>
 
-		<label class="group-name" for="yt_nocookie"><?php echo _t('ext.yt_videos.use_nocookie'); ?></label>
+		<label class="group-name" for="yt_nocookie"><?= _t('ext.yt_videos.use_nocookie') ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?php if ($this->getUseNoCookie()) { echo 'checked'; }; ?>>
+			<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->getUseNoCookie() ? 'checked' : '' ?>>
 		</div>
 	</div>
 
 	<div class="form-group form-actions">
 		<div class="group-controls">
-			<button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
-			<button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
+			<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+			<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 		</div>
 	</div>
 </form>
 
 <p>
-	<?php echo _t('ext.yt_videos.updates'); ?>
+	<?= _t('ext.yt_videos.updates') ?>
 	<a href="https://github.com/kevinpapst/freshrss-youtube" target="_blank">GitHub</a>.
 </p>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -21,7 +21,7 @@
 
 		<div class="group-controls">
 			<label class="checkbox" for="yt_nocookie">
-				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->getUseNoCookie() ? 'checked' : '' ?>>
+				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?= $this->isUseNoCookieDomain() ? 'checked' : '' ?>>
 				<?= _t('ext.yt_videos.use_nocookie') ?>
 			</label>
 		</div>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -16,9 +16,9 @@
 		
 		<label class="group-name" for="yt_content"><?php echo _t('ext.yt_videos.content.title'); ?></label>
 		<div class="group-controls">
-			<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?php if ($this->getContentHandling() == 'none') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.none'); ?><br />
-			<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?php if ($this->getContentHandling() == 'append') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.append'); ?><br />
-			<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?php if ($this->getContentHandling() == 'format') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.format'); ?><br />
+			<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?php if ($this->getContentHandling() === 'none') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.none'); ?><br />
+			<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?php if ($this->getContentHandling() === 'append') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.append'); ?><br />
+			<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?php if ($this->getContentHandling() === 'format') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.format'); ?><br />
 		</div>
 
 		<label class="group-name" for="yt_nocookie"><?php echo _t('ext.yt_videos.use_nocookie'); ?></label>

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -1,5 +1,3 @@
-<?php $this->loadConfigValues(); ?>
-
 <form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
 	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
 	<div class="form-group">

--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -1,3 +1,4 @@
+<?php $this->loadConfigValues(); ?>
 
 <form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
 	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
@@ -5,22 +6,24 @@
 
 		<label class="group-name" for="yt_height"><?php echo _t('ext.yt_videos.height'); ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_height" name="yt_height" value="<?php echo FreshRSS_Context::$user_conf->yt_player_height; ?>" min="50" data-leave-validation="1">
+			<input type="number" id="yt_height" name="yt_height" value="<?php echo $this->getHeight(); ?>" min="50" data-leave-validation="1">
 		</div>
 
 		<label class="group-name" for="yt_width"><?php echo _t('ext.yt_videos.width'); ?></label>
 		<div class="group-controls">
-			<input type="number" id="yt_width" name="yt_width" value="<?php echo FreshRSS_Context::$user_conf->yt_player_width; ?>" min="100" data-leave-validation="1">
+			<input type="number" id="yt_width" name="yt_width" value="<?php echo $this->getWidth(); ?>" min="100" data-leave-validation="1">
 		</div>
-
-		<label class="group-name" for="yt_show_content"><?php echo _t('ext.yt_videos.show_content'); ?></label>
+		
+		<label class="group-name" for="yt_content"><?php echo _t('ext.yt_videos.content.title'); ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_show_content" name="yt_show_content" value="1" <?php if (FreshRSS_Context::$user_conf->yt_show_content != '') { echo 'checked'; }; ?>>
+			<input type="radio" id="yt_content_none" name="yt_content_choice" value="none" <?php if ($this->getContentHandling() == 'none') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.none'); ?><br />
+			<input type="radio" id="yt_content_append" name="yt_content_choice" value="append" <?php if ($this->getContentHandling() == 'append') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.append'); ?><br />
+			<input type="radio" id="yt_content_format" name="yt_content_choice" value="format" <?php if ($this->getContentHandling() == 'format') { echo 'checked'; }; ?>> <?php echo _t('ext.yt_videos.content.format'); ?><br />
 		</div>
 
 		<label class="group-name" for="yt_nocookie"><?php echo _t('ext.yt_videos.use_nocookie'); ?></label>
 		<div class="group-controls">
-			<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?php if (FreshRSS_Context::$user_conf->yt_nocookie != '') { echo 'checked'; }; ?>>
+			<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?php if ($this->getUseNoCookie()) { echo 'checked'; }; ?>>
 		</div>
 	</div>
 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -206,7 +206,7 @@ class YouTubeExtension extends Minz_Extension
      */
     public function getHtml($entry, $url)
     {
-        $content = '[error]';
+        $content = '';
         
         $iframe = '<iframe class="youtube-plugin-video"
                 style="height: ' . $this->height . 'px; width: ' . $this->width . 'px;" 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -234,12 +234,18 @@ class YouTubeExtension extends Minz_Extension
                     $thumbnails = $xpath->evaluate("//*[@class='enclosure-thumbnail']/@src");
                     $descriptions = $xpath->evaluate("//*[@class='enclosure-description']");
 
+                    
                     $content = '<div class="enclosure">';
 
+                    // We hide the title so it doesn't appear in the final article, which would be redundant with the RSS article title,
+                    // but we keep it in the content anyway, so RSS clients can extract it if needed.
                     if ($titles->length > 0) {
                         $content .= '<p class="enclosure-title" hidden>' . $titles[0]->nodeValue . '</p>';
                     }
 
+                    // We hide the thumbnail so it doesn't appear in the final article, which would be redundant with the YouTube player preview,
+                    // but we keep it in the content anyway, so RSS clients can extract it to display a preview where it wants (in article listing,
+                    // by example, like with Reeder).
                     if ($thumbnails->length > 0) {
                         $content .= '<p hidden><img class="enclosure-thumbnail" src="' . $thumbnails[0]->nodeValue . '" alt=""/></p>';
                     }

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -252,7 +252,6 @@ class YouTubeExtension extends Minz_Extension
 
                     $content .= "</div>\n";
                 }
-
                 break;
             default:
                 $content = $iframe;

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -111,7 +111,7 @@ class YouTubeExtension extends Minz_Extension
      *
      * @return bool
      */
-    public function getShowContent()
+    public function isShowContent()
     {
         return $this->showContent;
     }

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -217,9 +217,6 @@ class YouTubeExtension extends Minz_Extension
                 allowFullScreen></iframe>';
         
         switch ($this->contentHandling) {
-            case 'none':
-                $content = $iframe;
-                break;
             case 'append':
                 $content = $iframe . $entry->content();
                 break;
@@ -256,6 +253,9 @@ class YouTubeExtension extends Minz_Extension
                     $content .= "</div>\n";
                 }
 
+                break;
+            default:
+                $content = $iframe;
                 break;
         }
 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -153,10 +153,10 @@ class YouTubeExtension extends Minz_Extension
             return $entry;
         }
         if (stripos($link, 'www.youtube.com/watch?v=') !== false) {
-            $html = $this->forgeContentForLink($entry, $link);
+            $html = $this->getHtmlContentForLink($entry, $link);
         }
         else{ //peertube
-            $html = $this->forgePeerTubeContentForLink($entry, $link);
+            $html = $this->getHtmlPeerTubeContentForLink($entry, $link);
         }
 
         $entry->_content($html);
@@ -170,7 +170,7 @@ class YouTubeExtension extends Minz_Extension
      * @param string $link
      * @return string
      */
-    public function forgeContentForLink($entry, $link)
+    public function getHtmlContentForLink($entry, $link)
     {
         $domain = 'www.youtube.com';
         if ($this->useNoCookie) {
@@ -179,7 +179,7 @@ class YouTubeExtension extends Minz_Extension
         $url = str_replace('//www.youtube.com/watch?v=', '//'.$domain.'/embed/', $link);
         $url = str_replace('http://', 'https://', $url);
 
-        $html = $this->forgeHtml($entry, $url);
+        $html = $this->getHtml($entry, $url);
 
         return $html;
     }
@@ -190,10 +190,10 @@ class YouTubeExtension extends Minz_Extension
     * @param string $link
     * @return string
     */
-    public function forgePeerTubeContentForLink($entry, $link)
+    public function getHtmlPeerTubeContentForLink($entry, $link)
     {
         $url = str_replace('/watch', '/embed', $link);
-        $html = $this->forgeHtml($entry, $url);
+        $html = $this->getHtml($entry, $url);
         
         return $html;
     }
@@ -204,7 +204,7 @@ class YouTubeExtension extends Minz_Extension
      * @param string $url
      * @return string
      */
-    public function forgeHtml($entry, $url)
+    public function getHtml($entry, $url)
     {
         $content = '[error]';
         

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -122,7 +122,7 @@ class YouTubeExtension extends Minz_Extension
      *
      * @return bool
      */
-    public function getUseNoCookie()
+    public function isUseNoCookieDomain()
     {
         return $this->useNoCookie;
     }

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -269,20 +269,22 @@ class YouTubeExtension extends Minz_Extension
     }
 
     /**
-     * Saves the user settings for this extension.
+     * This function is called by FreshRSS when the configuration page is loaded, and when configuration is saved.
+     *  - We save configuration in case of a post.
+     *  - We (re)load configuration in all case, so they are in-sync after a save and before a page load.
      */
     public function handleConfigureAction()
     {
         $this->registerTranslates();
 
-        $this->loadConfigValues();
-
         if (Minz_Request::isPost()) {
             FreshRSS_Context::$user_conf->yt_player_height = (int)Minz_Request::param('yt_height', '');
             FreshRSS_Context::$user_conf->yt_player_width = (int)Minz_Request::param('yt_width', '');
-            FreshRSS_Context::$user_conf->yt_content_handling = (string)Minz_Request::param('yt_content_choice', '');
+            FreshRSS_Context::$user_conf->yt_content_handling = Minz_Request::param('yt_content_choice', '');
             FreshRSS_Context::$user_conf->yt_nocookie = (int)Minz_Request::param('yt_nocookie', 0);
             FreshRSS_Context::$user_conf->save();
         }
+
+        $this->loadConfigValues();
     }
 }

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -1,16 +1,16 @@
 <?php
 
 return array(
-	'yt_videos' => array(
-		'height' => 'Höhe des Players',
+    'yt_videos' => array(
+        'height' => 'Höhe des Players',
         'width' => 'Breite des Players',
         'updates' => 'Die neueste Version des Plugins findest Du bei',
         'content' => array(
-		    'title' => 'Content', // @todo translate
-		    'none' => 'Player Only', // @todo translate
-		    'append' => 'Player + Basic Content', // @todo translate
-		    'format' => 'Player + Enhanced Content', // @todo translate
-		),
+            'title' => 'Content', // @todo translate
+            'none' => 'Player Only', // @todo translate
+            'append' => 'Player + Basic Content', // @todo translate
+            'format' => 'Player + Enhanced Content', // @todo translate
+        ),
         'use_nocookie' => 'Verwende die Cookie-freie Domain www.youtube-nocookie.com',
-	),
+    ),
 );

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -7,9 +7,9 @@ return array(
         'updates' => 'Die neueste Version des Plugins findest Du bei',
         'content' => array(
 		    'title' => 'Content', // @todo translate
-		    'none' => 'None', // @todo translate
-		    'append' => 'Append', // @todo translate
-		    'format' => 'Format', // @todo translate
+		    'none' => 'Player Only', // @todo translate
+		    'append' => 'Player + Basic Content', // @todo translate
+		    'format' => 'Player + Enhanced Content', // @todo translate
 		),
         'use_nocookie' => 'Verwende die Cookie-freie Domain www.youtube-nocookie.com',
 	),

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -5,7 +5,12 @@ return array(
 		'height' => 'Höhe des Players',
         'width' => 'Breite des Players',
         'updates' => 'Die neueste Version des Plugins findest Du bei',
-		'show_content' => 'Zeige den Inhalt des Feeds an',
+        'content' => array(
+		    'title' => 'Content', // @todo translate
+		    'none' => 'None', // @todo translate
+		    'append' => 'Append', // @todo translate
+		    'format' => 'Format', // @todo translate
+		),
         'use_nocookie' => 'Verwende die Cookie-freie Domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -5,12 +5,7 @@ return array(
         'height' => 'Höhe des Players',
         'width' => 'Breite des Players',
         'updates' => 'Die neueste Version des Plugins findest Du bei',
-        'content' => array(
-            'title' => 'Content', // @todo translate
-            'none' => 'Player Only', // @todo translate
-            'append' => 'Player + Basic Content', // @todo translate
-            'format' => 'Player + Enhanced Content', // @todo translate
-        ),
+        'show_content' => 'Zeige den Inhalt des Feeds an',
         'use_nocookie' => 'Verwende die Cookie-freie Domain www.youtube-nocookie.com',
     ),
 );

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -5,7 +5,12 @@ return array(
 		'height' => 'Player height',
         'width' => 'Player width',
         'updates' => 'You can find the latest extension version at',
-		'show_content' => 'Display the feeds content',
+        'content' => array(
+		    'title' => 'Content',
+		    'none' => 'None',
+		    'append' => 'Append',
+		    'format' => 'Format',
+		),
         'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -5,12 +5,7 @@ return array(
 		'height' => 'Player height',
 		'width' => 'Player width',
 		'updates' => 'You can find the latest extension version at',
-		'content' => array(
-			'title' => 'Content',
-			'none' => 'Player Only',
-			'append' => 'Player + Basic Content',
-			'format' => 'Player + Enhanced Content',
-		),
+		'show_content' => 'Display the feeds content',
 		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -7,9 +7,9 @@ return array(
         'updates' => 'You can find the latest extension version at',
         'content' => array(
 		    'title' => 'Content',
-		    'none' => 'None',
-		    'append' => 'Append',
-		    'format' => 'Format',
+		    'none' => 'Player Only',
+		    'append' => 'Player + Basic Content',
+		    'format' => 'Player + Enhanced Content',
 		),
         'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
 	),

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -3,14 +3,14 @@
 return array(
 	'yt_videos' => array(
 		'height' => 'Player height',
-        'width' => 'Player width',
-        'updates' => 'You can find the latest extension version at',
-        'content' => array(
-		    'title' => 'Content',
-		    'none' => 'Player Only',
-		    'append' => 'Player + Basic Content',
-		    'format' => 'Player + Enhanced Content',
+		'width' => 'Player width',
+		'updates' => 'You can find the latest extension version at',
+		'content' => array(
+			'title' => 'Content',
+			'none' => 'Player Only',
+			'append' => 'Player + Basic Content',
+			'format' => 'Player + Enhanced Content',
 		),
-        'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
+		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -5,12 +5,7 @@ return array(
 		'height' => 'Hauteur du lecteur',
 		'width' => 'Largeur du lecteur',
 		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
-		'content' => array(
-			'title' => 'Contenu',
-			'none' => 'Lecteur seul',
-			'append' => 'Lecteur + Contenu basique',
-			'format' => 'Lecteur + Contenu amélioré',
-		),
+		'show_content' => 'Afficher le contenu du fil',
 		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
 	),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -5,7 +5,7 @@ return array(
 		'height' => 'Hauteur du lecteur',
 		'width' => 'Largeur du lecteur',
 		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
-		'show_content' => 'Afficher le contenu du fil',
+		'show_content' => 'Afficher le contenu du flux',
 		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
 	),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -1,16 +1,16 @@
 <?php
 return 
-  array(	
-	'yt_videos' => array(
-		'height' => 'Hauteur du lecteur',
-		'width' => 'Largeur du lecteur',
-		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
+  array(
+    'yt_videos' => array(
+        'height' => 'Hauteur du lecteur',
+        'width' => 'Largeur du lecteur',
+        'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
         'content' => array(
-		    'title' => 'Contenu',
-		    'none' => 'Lecteur seul',
-		    'append' => 'Lecteur + Contenu basique',
-		    'format' => 'Lecteur + Contenu amélioré',
-		),
+            'title' => 'Contenu',
+            'none' => 'Lecteur seul',
+            'append' => 'Lecteur + Contenu basique',
+            'format' => 'Lecteur + Contenu amélioré',
+        ),
         'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
   ),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -6,10 +6,10 @@ return
 		'width' => 'Largeur du lecteur',
 		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
         'content' => array(
-		    'title' => 'Contenus',
-		    'none' => 'Aucun',
-		    'append' => 'Ajouter',
-		    'format' => 'Formater',
+		    'title' => 'Contenu',
+		    'none' => 'Lecteur seul',
+		    'append' => 'Lecteur + Contenu basique',
+		    'format' => 'Lecteur + Contenu amélioré',
 		),
         'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
   ),

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -5,7 +5,12 @@ return
 		'height' => 'Hauteur du lecteur',
 		'width' => 'Largeur du lecteur',
 		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
-		'show_content' => 'Display the feeds content', // @todo translate
+        'content' => array(
+		    'title' => 'Contenus',
+		    'none' => 'Aucun',
+		    'append' => 'Ajouter',
+		    'format' => 'Formater',
+		),
         'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
   ),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -1,16 +1,16 @@
 <?php
-return 
-  array(
-    'yt_videos' => array(
-        'height' => 'Hauteur du lecteur',
-        'width' => 'Largeur du lecteur',
-        'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
-        'content' => array(
-            'title' => 'Contenu',
-            'none' => 'Lecteur seul',
-            'append' => 'Lecteur + Contenu basique',
-            'format' => 'Lecteur + Contenu amélioré',
-        ),
-        'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
-  ),
+
+return array(
+	'yt_videos' => array(
+		'height' => 'Hauteur du lecteur',
+		'width' => 'Largeur du lecteur',
+		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
+		'content' => array(
+			'title' => 'Contenu',
+			'none' => 'Lecteur seul',
+			'append' => 'Lecteur + Contenu basique',
+			'format' => 'Lecteur + Contenu amélioré',
+		),
+		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
+	),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -6,6 +6,6 @@ return array(
 		'width' => 'Largeur du lecteur',
 		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
 		'show_content' => 'Afficher le contenu du flux',
-		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com', // @todo translate
+		'use_nocookie' => 'Utiliser le domaine www.youtube-nocookie.com pour éviter les cookies',
 	),
 );


### PR DESCRIPTION
Hello,

Here is a change proposal that I'm using and that I think can be interesting to include in the main project.

The global idea is that it was interesting to me to add the original YouTube feed content in articles (in addition to the iframe), as it includes some description / comment from the author, but the FreshRSS generic rendering of this content was not good enough:
- The description uses a `<pre>` node, which is a bit "raw".
- Thumbnail is visible, so it's a bit duplication with the preview of the YouTube player we can see in the iframe.

So I added a bit more evolved formatting:
- The description is now in a `<p>` node, so it shows as standard text.
- Thumbnail is added, but **hidden**, this way RSS clients (like mine) can still extract it to show a content preview, but then it's not redundant in the article itself with the iframe.
- The title is hidden, as RSS clients already know it (but still included, so if some RSS client extract it, it's still available).

I wanted to keep the choice of feed content inclusion, so I converted the original "show-content" checkbox to a group of radio buttons, so the user can choose between "None" (i.e doesn't include original feed content, i.e. show only the iframe), "Append" (i.e. iframe + content generated by FreshRSS) and "Format" (i.e. iframe + reformatted original feed content).

It's possible that naming of the 3 modes have to be enhanced…

On a side point, I changed a bit configuration handling:
- The code was in duplication with what was already done in `extension.php`, which was a bit annoying for my change.
- The `empty(FreshRSS_Context::$user_conf->yt_xxx)` was not working on my side, for some reason (always returning true, so never actually reading settings). Not sure what is the point, but I changed to a simple `!= ''` comparison.

Note:
- I'm using `nl2br(htmlentities($descriptions[0]->nodeValue))`, because, as an YouTube extension, we know that description will be always pure text, and not pre-formated HTML (well, except if YouTube decide one day to give pre-formated HTML content…).

I'm not a PHP developer, so I might have didn't do it well.

If you are not interested in this change, feel free to reject it, I will keep it for myself ;)

Finally, some screen-shot to show the 3 modes in my RSS client (Reeder):
- "None":
<img width="1497" alt="yt_none" src="https://user-images.githubusercontent.com/1971659/72223880-0257ac00-3574-11ea-93bb-556cad0d7217.png">
 
- "Append":
<img width="1497" alt="yt_append" src="https://user-images.githubusercontent.com/1971659/72223884-13082200-3574-11ea-8d8f-3a5b127aad88.png">

- "Format":
<img width="1497" alt="yt_format" src="https://user-images.githubusercontent.com/1971659/72223886-18fe0300-3574-11ea-9773-2d597e780aa6.png">
