### PR TITLE
Fix extension definition

### DIFF
--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -30,6 +30,14 @@ class YouTubeExtension extends Minz_Extension
      */
     protected $useNoCookie = false;
 
+    public function install() {
+        return true;
+    }
+
+    public function uninstall() {
+        return true;
+    }
+
     /**
      * Initialize this extension
      */


### PR DESCRIPTION
Before, extension was missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extension have all mandatory method definitions.